### PR TITLE
BTT TFTs should be using M575 S2 per BTT docs

### DIFF
--- a/templates/config.ejs
+++ b/templates/config.ejs
@@ -378,7 +378,7 @@ M567 P<%- tool.number %> E<%- tool.mix_ratio.join(':') %> ; set mixing ratios fo
 M575 P1 S0 B57600 ; enable support for Flymaker 4.3/7" screen
 <%		}
 		if (template.tft) { -%>
-M575 P1 S1 B115200 ; enable support for tft
+M575 P1 S2 B115200 ; enable support for tft
 <%		}
 		if (template.panelDue) { -%>
 M575 P1 S1 B57600 ; enable support for PanelDue


### PR DESCRIPTION
See [here](https://github.com/bigtreetech/BIGTREETECH-TouchScreenFirmware#tft-screen-configuration-and-support-for-rrf)